### PR TITLE
[FIX] 아이디어 등록 페이지 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.66.0",
         "react-router-dom": "^7.4.1",
+        "react-toastify": "^11.0.5",
         "zod": "^4.1.12",
         "zustand": "^5.0.8"
       },
@@ -6843,6 +6844,19 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.66.0",
     "react-router-dom": "^7.4.1",
+    "react-toastify": "^11.0.5",
     "zod": "^4.1.12",
     "zustand": "^5.0.8"
   },

--- a/src/App.css
+++ b/src/App.css
@@ -37,3 +37,18 @@
 .read-the-docs {
   color: #888;
 }
+
+.Toastify__toast {
+  width: 809px;
+  height: 132px;
+  background: transparent !important;
+  box-shadow: none !important;
+  border-radius: 10px;
+  padding: 0 !important;
+  overflow: hidden !important;
+}
+
+.Toastify__toast-body {
+  padding: 0 !important;
+  margin: 0 !important;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,21 @@
 import Router from './Router';
-
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 import './App.css';
 
 function App() {
-  return <Router />;
+  return (
+    <>
+      <Router />
+      <ToastContainer
+        hideProgressBar
+        closeButton={false}
+        icon={false}
+        position="top-center"
+        autoClose={3000}
+      />
+    </>
+  );
 }
 
 export default App;

--- a/src/components/TeamMatching/IdeaRegister/IdeaRegisterHeader.tsx
+++ b/src/components/TeamMatching/IdeaRegister/IdeaRegisterHeader.tsx
@@ -2,18 +2,25 @@ import { useFormContext } from 'react-hook-form';
 import RoundedSquareButton from '../../commons/RoundedSquareButton';
 import { IdeaRegisterSchema } from './schema/ideaRegisterSchema';
 import useIdeaRegister from '../../../hooks/useIdeaRegister';
+import { toast } from 'react-toastify';
+import Toast from '../../commons/Toast';
+import { useNavigate } from 'react-router-dom';
 
 const IdeaRegisterHeader = () => {
   const {
     handleSubmit,
     formState: { isSubmitting },
   } = useFormContext<IdeaRegisterSchema>();
+  const navigate = useNavigate();
   const ideaRegister = useIdeaRegister();
 
   const onSubmit = handleSubmit(
     (data) => {
-      console.log('✅ 제출 성공:', data);
-      ideaRegister(data);
+      ideaRegister(data).then(() => {
+        toast(<Toast message="아이디어 등록이 완료되었어요." />, {
+          onClose: () => navigate('/team-matching'),
+        });
+      });
     },
     (errors) => console.log('❌ 유효성 에러:', errors)
   );

--- a/src/components/commons/Toast.tsx
+++ b/src/components/commons/Toast.tsx
@@ -1,0 +1,9 @@
+const CustomToast = ({ message }: { message: string }) => {
+  return (
+    <div className="w-[809px] h-[132px] bg-[linear-gradient(180deg,_#17222C_0%,_#203536_100%)] rounded-xl px-6 py-4 flex items-center justify-center text-36 font-700 text-white">
+      {message}
+    </div>
+  );
+};
+
+export default CustomToast;

--- a/src/hooks/useIdeaRegister.ts
+++ b/src/hooks/useIdeaRegister.ts
@@ -58,9 +58,8 @@ const useIdeaRegister = () => {
       };
 
       const res = await api.post(ENDPOINTS.IDEAS, toServerData);
-      if (res.data.success) {
-        console.log('아이디어 등록 성공');
-      }
+
+      return res.data.success;
     } catch (err) {
       console.error('아이디어 등록 실패:', err);
     }


### PR DESCRIPTION
## ➕ 이슈 링크
- closes #43 

## ✏️ 작업 내용

- 아이디어 등록 페이지에서 아이디어 등록이 제대로 되지 않는 오류를 수정했습니다
- 아이디어 등록 후 팝업 토스트를 추가했습니다

## 📷 스크린샷



## 🎸 기타

- 추가된 의존성 : react-toastify
- useApi 훅을 이용하면 기본적으로 토큰을 같이 전송하도록 설정했습니다. 따라서 만약에 어떤 요청의 경우 토큰을 추가하지 않고싶다면 
   ```
   const response = await api.get(`/oauth2/code/discord?code=${code}`, { skipAuth: true });
   ```
   이런식으로 skipAuth프로퍼티에 true값을 넣은 객체를 요청함수에 추가해주시면됩니다
