### PR TITLE
[FEAT] 아티클 편집 페이지 서버 없는 기능

### DIFF
--- a/src/components/ArticleForm/ArticleEditForm.tsx
+++ b/src/components/ArticleForm/ArticleEditForm.tsx
@@ -1,0 +1,220 @@
+import { useRef } from 'react';
+import { useFieldArray, useForm } from 'react-hook-form';
+import TextareaAutosize from 'react-textarea-autosize';
+import clsx from 'clsx';
+
+import {
+  ArticleApiData,
+  ArticleFormData,
+  ArticleFormFields,
+  BlockType,
+  getBlockKey,
+  normalizePositions,
+} from './ArticleFormFields';
+import { EmptyForm } from './EmptyForm';
+
+import KUITLogo from '/KUITLogo.svg';
+
+const ToolbarButton = ({ label, onClick }: { label: string; onClick?: () => void }) => {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={clsx(
+        'px-[19px] py-[12px] rounded-[10px] h-[48px] border border-border flex-center bg-gray text-white',
+        'hover:bg-main hover:text-[#18232d] hover:border-bg-main',
+        'text-[20px] font-700 font-bold tracking-[0]'
+      )}
+    >
+      {label}
+    </button>
+  );
+};
+
+const HORIZONTAL_PADDING = 'px-[47px] pr-[44px]';
+
+interface ArticleEditFormProps {
+  defaultValues?: ArticleFormData;
+  // onAPIData: 이 함수로 실제 통신 코드, 컴포넌트내 submit은 폼 데이터 가공만
+}
+
+export const ArticleEditForm = ({ defaultValues }: ArticleEditFormProps) => {
+  // defaultValues 정규화: position을 0부터 순차적으로 재정렬
+  const normalizedDefaultValues: ArticleFormData = defaultValues
+    ? {
+        title: defaultValues.title,
+        blocks: normalizePositions(defaultValues.blocks),
+      }
+    : {
+        title: '',
+        blocks: [],
+      };
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const headerRef = useRef<HTMLElement>(null);
+
+  const { control, register, handleSubmit } = useForm<ArticleFormData>({
+    defaultValues: normalizedDefaultValues,
+  });
+
+  const { fields, append } = useFieldArray({
+    control,
+    name: 'blocks',
+  });
+  // TODO: 삭제 기능 도입 시 remove도 사용
+  // const { fields, append, remove } = useFieldArray({
+  //   control,
+  //   name: 'blocks',
+  // });
+
+  const addField = (type: BlockType) => {
+    const id = `${type}-${Date.now()}`;
+    const position = fields.length;
+
+    if (type === 'SUB_TITLE' || type === 'TEXT') {
+      append({
+        id,
+        position,
+        type,
+        properties: {
+          title: '',
+        },
+      });
+    } else if (type === 'CODE') {
+      append({
+        id,
+        position,
+        type,
+        properties: {
+          title: '',
+          code_lang: '',
+        },
+      });
+    } else if (type === 'FILE' || type === 'URL' || type === 'IMAGE') {
+      append({
+        id,
+        position,
+        type,
+        properties: {
+          url: '',
+          title: '',
+        },
+      });
+    }
+    // 필드 추가시 밑으로 내림
+    const scrollHeight = containerRef.current?.scrollHeight ?? 0;
+    requestAnimationFrame(() => {
+      // 경험상 320이 좋아보임, 하드코딩인데 이걸 풀 방법은 모르겠음
+      const top = Math.max(0, scrollHeight - 320);
+      containerRef.current?.scrollTo({
+        top,
+        behavior: 'smooth',
+      });
+    });
+  };
+
+  const onSubmit = (data: ArticleFormData) => {
+    // position을 0부터 순차적으로 정규화 후 API 형식으로 변환
+    const normalizedBlocks = normalizePositions(data.blocks);
+    const apiData: ArticleApiData = {
+      title: data.title,
+      blocks: normalizedBlocks.map((block) => {
+        const properties: Record<string, string> = {};
+
+        if (block.type === 'SUB_TITLE' || block.type === 'TEXT') {
+          properties.title = block.properties.title;
+        } else if (block.type === 'CODE') {
+          properties.title = block.properties.title;
+          // TODO: 언어 선택은 나중에, 딱히 Ui가 없음
+          properties.code_lang = 'Python';
+        } else if (block.type === 'FILE' || block.type === 'URL' || block.type === 'IMAGE') {
+          properties.url = block.properties.url;
+          properties.title = block.properties.title || '제목없음';
+        }
+
+        const apiBlock: ArticleApiData['blocks'][0] = {
+          position: block.position,
+          type: block.type,
+          properties: JSON.stringify(properties),
+        };
+
+        if (block.type === 'CODE' && block.properties.code_lang) {
+          apiBlock.language = block.properties.code_lang;
+        }
+
+        return apiBlock;
+      }),
+    };
+
+    console.log('API data:', apiData);
+    // TODO: API 호출
+  };
+
+  // 삭제 기능 (나중에 사용)
+  // const deleteField = (index: number) => {
+  //   // remove는 useFieldArray에서 가져와야 함
+  //   // remove(index);
+  //   // position은 onSubmit 시점에 normalizePositions로 자동 정규화됨 (0부터 순차적으로)
+  // };
+
+  return (
+    <div className="relative bg-gradient h-screen overflow-y-auto" ref={containerRef}>
+      {/* Top toolbar */}
+      <header
+        className={clsx(
+          'w-full h-[141px] flex items-center justify-between bg-gray sticky top-0',
+          HORIZONTAL_PADDING,
+          'pt-[55px] pb-[38px]'
+        )}
+        ref={headerRef}
+      >
+        <div className="flex gap-[47px]">
+          <img src={KUITLogo} alt="KUIT Logo" width={63} height={55} />
+          <div className="flex gap-[14px]">
+            <ToolbarButton label="사진" onClick={() => addField('IMAGE')} />
+            <ToolbarButton label="링크" onClick={() => addField('URL')} />
+            <ToolbarButton label="파일" onClick={() => addField('FILE')} />
+            <ToolbarButton label="코드" onClick={() => addField('CODE')} />
+            <ToolbarButton label="본문" onClick={() => addField('TEXT')} />
+            <ToolbarButton label="소제목" onClick={() => addField('SUB_TITLE')} />
+          </div>
+        </div>
+        <div className="flex gap-12">
+          <ToolbarButton label="미리보기" />
+          <ToolbarButton label="등록하기" onClick={handleSubmit(onSubmit)} />
+        </div>
+      </header>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <TextareaAutosize
+          {...register('title')}
+          placeholder="제목을 입력해주세요."
+          className={clsx(
+            HORIZONTAL_PADDING,
+            'text-[48px] font-700 text-main w-full bg-transparent outline-none pt-[56px] pb-[40px]'
+          )}
+          autoFocus
+        />
+        <hr className="w-full h-[9px] bg-[#2c373f]" />
+        <div
+          className={clsx(
+            HORIZONTAL_PADDING,
+            'w-full flex flex-col gap-[27px] pt-[40px] pb-[180px]'
+          )}
+        >
+          {fields.length === 0 ? (
+            <EmptyForm />
+          ) : (
+            fields.map((field, index) => (
+              <ArticleFormFields
+                key={getBlockKey(field)}
+                field={field}
+                index={index}
+                control={control}
+              />
+            ))
+          )}
+        </div>
+      </form>
+    </div>
+  );
+};

--- a/src/components/ArticleForm/ArticleFormFields.tsx
+++ b/src/components/ArticleForm/ArticleFormFields.tsx
@@ -1,0 +1,229 @@
+import { Control, Controller } from 'react-hook-form';
+
+import FileField from '../form/FileField';
+import ImageField from '../form/ImageField';
+import LinkField, { LinkModal, LinkModalTrigger } from '../form/LinkField';
+
+import { BodyField } from './BodyField';
+import { CodeField } from './CodeField';
+import { SectionTitleField } from './SectionTitleField';
+
+export type BlockType = 'SUB_TITLE' | 'TEXT' | 'CODE' | 'FILE' | 'URL' | 'IMAGE';
+
+export interface TextBlock {
+  type: 'SUB_TITLE' | 'TEXT';
+  properties: {
+    title: string;
+  };
+}
+
+export interface CodeBlock {
+  type: 'CODE';
+  properties: {
+    title: string;
+    code_lang: string;
+  };
+}
+
+export interface ResourceBlock {
+  type: 'FILE' | 'URL' | 'IMAGE';
+  properties: {
+    url: string;
+    title: string;
+  };
+}
+
+export type ContentBlock = { id: string; position: number } & (
+  | TextBlock
+  | CodeBlock
+  | ResourceBlock
+);
+
+export interface ArticleFormData {
+  title: string;
+  /**
+   * warn: must stringify properties when sending to API
+   */
+  blocks: ContentBlock[];
+}
+
+// API 응답 형식
+export interface ArticleBlock {
+  position: number;
+  type: BlockType;
+  properties: string; // JSON string
+  language?: string; // CODE 타입일 때만
+}
+
+export interface ArticleApiData {
+  title: string;
+  blocks: ArticleBlock[];
+}
+
+// API 데이터를 폼 데이터로 변환하는 유틸 함수
+export const convertApiDataToFormData = (apiData: ArticleApiData): ArticleFormData => {
+  return {
+    title: apiData.title,
+    blocks: apiData.blocks.map((block) => {
+      const properties = JSON.parse(block.properties);
+      const id = `${block.type}-${block.position}-${Date.now()}`;
+
+      if (block.type === 'SUB_TITLE' || block.type === 'TEXT') {
+        return {
+          id,
+          position: block.position,
+          type: block.type,
+          properties: {
+            title: properties.title || '',
+          },
+        };
+      } else if (block.type === 'CODE') {
+        return {
+          id,
+          position: block.position,
+          type: block.type,
+          properties: {
+            title: properties.title || '',
+            code_lang: properties.code_lang || block.language || '',
+          },
+        };
+      } else {
+        return {
+          id,
+          position: block.position,
+          type: block.type,
+          properties: {
+            url: properties.url || '',
+            title: properties.title || '',
+          },
+        };
+      }
+    }),
+  };
+};
+
+// ContentBlock에서 key를 구하는 함수 (항상 id 사용, id는 항상 존재)
+export const getBlockKey = (block: ContentBlock): string => {
+  return block.id;
+};
+
+// position을 0부터 순차적으로 재정렬하는 정규화 함수 (삭제 후 사용)
+export const normalizePositions = (blocks: ContentBlock[]): ContentBlock[] => {
+  return blocks.map((block, index) => ({
+    ...block,
+    position: index,
+  }));
+};
+
+interface ArticleFormFieldsProps {
+  field: ContentBlock;
+  index: number;
+  control: Control<ArticleFormData>;
+}
+
+export const ArticleFormFields = ({ field, index, control }: ArticleFormFieldsProps) => {
+  switch (field.type) {
+    case 'SUB_TITLE':
+      return (
+        <Controller
+          name={`blocks.${index}.properties.title`}
+          control={control}
+          render={({ field: { onChange, value } }) => (
+            <SectionTitleField
+              value={value || ''}
+              onChange={(e) => onChange(e.target.value)}
+              placeholder="소제목을 입력해주세요."
+              autoFocus
+            />
+          )}
+        />
+      );
+    case 'TEXT':
+      return (
+        <Controller
+          name={`blocks.${index}.properties.title`}
+          control={control}
+          render={({ field: { onChange, value } }) => (
+            <BodyField
+              value={value || ''}
+              onChange={(e) => onChange(e.target.value)}
+              placeholder="본문을 입력해주세요."
+              autoFocus
+            />
+          )}
+        />
+      );
+    case 'CODE':
+      return (
+        <Controller
+          name={`blocks.${index}.properties.title`}
+          control={control}
+          render={({ field: { onChange, value } }) => (
+            <CodeField
+              value={value || ''}
+              onChange={(e) => onChange(e.target.value)}
+              placeholder="코드를 입력해주세요."
+              autoFocus
+            />
+          )}
+        />
+      );
+    case 'URL':
+      return (
+        <Controller
+          name={`blocks.${index}.properties.url`}
+          control={control}
+          render={({ field: { onChange, value } }) => (
+            <LinkField link={value || ''}>
+              <LinkModalTrigger />
+              <LinkModal
+                value={value || ''}
+                onChange={(e) => onChange(e.target.value)}
+                placeholder="URL을 입력해주세요."
+              />
+            </LinkField>
+          )}
+        />
+      );
+    case 'IMAGE':
+      return (
+        <Controller
+          name={`blocks.${index}.properties.url`}
+          control={control}
+          render={({ field: { onChange } }) => (
+            <ImageField
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                if (file) {
+                  const reader = new FileReader();
+                  reader.onloadend = () => {
+                    onChange(reader.result as string);
+                  };
+                  reader.readAsDataURL(file);
+                }
+              }}
+            />
+          )}
+        />
+      );
+    case 'FILE':
+      return (
+        <Controller
+          name={`blocks.${index}.properties.url`}
+          control={control}
+          render={({ field: { onChange } }) => (
+            <FileField
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                if (file) {
+                  onChange(URL.createObjectURL(file));
+                }
+              }}
+            />
+          )}
+        />
+      );
+    default:
+      return null;
+  }
+};

--- a/src/components/ArticleForm/EmptyForm.tsx
+++ b/src/components/ArticleForm/EmptyForm.tsx
@@ -1,0 +1,9 @@
+import clsx from 'clsx';
+
+export const EmptyForm = () => {
+  return (
+    <div className={clsx('w-full flex flex-col items-center justify-center py-80 gap-24')}>
+      <p className="text-white text-24 font-500">상단 도구 모음에서 콘텐츠를 추가해주세요.</p>
+    </div>
+  );
+};

--- a/src/pages/Article/ArticleEdit.tsx
+++ b/src/pages/Article/ArticleEdit.tsx
@@ -1,89 +1,14 @@
-import TextareaAutosize from 'react-textarea-autosize';
-import clsx from 'clsx';
+import { ArticleFormData } from '../../components/ArticleForm/ArticleFormFields';
+import { ArticleEditForm } from '../../components/ArticleForm/ArticleEditForm';
 
-import { BodyField } from '../../components/ArticleForm/BodyField';
-import { CodeField } from '../../components/ArticleForm/CodeField';
-import { SectionTitleField } from '../../components/ArticleForm/SectionTitleField';
-import FileField from '../../components/form/FileField';
-import ImageField from '../../components/form/ImageField';
-import LinkField, { LinkModal, LinkModalTrigger } from '../../components/form/LinkField';
-
-import KUITLogo from '/KUITLogo.svg';
-
-const ToolbarButton = ({ label, onClick }: { label: string; onClick?: () => void }) => {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={clsx(
-        'px-[19px] py-[12px] rounded-[10px] h-[48px] border border-border flex-center bg-gray text-white',
-        'hover:bg-main hover:text-[#18232d] hover:border-bg-main',
-        'text-[20px] font-700 font-bold tracking-[0]'
-      )}
-    >
-      {label}
-    </button>
-  );
+// Mock data for testing
+const mockData: ArticleFormData = {
+  title: '샘플 제목',
+  blocks: [],
 };
 
-const HORIZONTAL_PADDING = 'px-[47px] pr-[44px]';
-
 const ArticleEdit = () => {
-  return (
-    <div className="relative bg-signup-gradient min-h-screen">
-      {/* Top toolbar */}
-      <header
-        className={clsx(
-          'w-full h-[141px] flex items-center justify-between bg-gray sticky top-0',
-          HORIZONTAL_PADDING,
-          'pt-[55px] pb-[38px]'
-        )}
-      >
-        <div className="flex gap-[47px]">
-          <img src={KUITLogo} alt="KUIT Logo" width={63} height={55} />
-          <div className="flex gap-[14px]">
-            <ToolbarButton label="사진" />
-            <ToolbarButton label="링크" />
-            <ToolbarButton label="파일" />
-            <ToolbarButton label="코드" />
-            <ToolbarButton label="본문" />
-            <ToolbarButton label="소제목" />
-          </div>
-        </div>
-        <div className="flex gap-12">
-          <ToolbarButton label="미리보기" />
-          <ToolbarButton label="등록하기" />
-        </div>
-      </header>
-      <form>
-        <TextareaAutosize
-          name="title"
-          placeholder="제목을 입력해주세요."
-          className={clsx(
-            HORIZONTAL_PADDING,
-            'text-[48px] font-700 text-main w-full bg-transparent outline-none pt-[56px] pb-[40px]'
-          )}
-        />
-        <hr className="w-full h-[9px] bg-[#2c373f]" />
-        <div
-          className={clsx(
-            HORIZONTAL_PADDING,
-            'w-full flex flex-col gap-[27px] pt-[40px] pb-[180px]'
-          )}
-        >
-          <SectionTitleField name="sectionTitle" placeholder="소제목을 입력해주세요." />
-          <BodyField name="body" placeholder="본문을 입력해주세요." />
-          <CodeField name="code" placeholder="코드를 입력해주세요." />
-          <LinkField link="">
-            <LinkModalTrigger />
-            <LinkModal />
-          </LinkField>
-          <ImageField />
-          <FileField />
-        </div>
-      </form>
-    </div>
-  );
+  return <ArticleEditForm defaultValues={mockData} />;
 };
 
 export default ArticleEdit;


### PR DESCRIPTION
## ➕ 이슈 링크
- closes #34

## ✏️ 작업 내용
draft 풀때까지 리뷰 보류해주세여
- 삭제기능은 아직 정해진바 없어 생략
- 버튼 누르면 폼 필드 추가
- 폼 데이터 서버 명세에 맞춰 관리
- 폼 필드 없을때 문구 추가
TODO: 폼 데이터 검증 기능
## 📷 스크린샷



## 🎸 기타

- https://www.notion.so/1cefabc2141a807eb763f54872271af6?source=copy_link
